### PR TITLE
Page lookup service cache strategy

### DIFF
--- a/lib/pages/lookup-service.ts
+++ b/lib/pages/lookup-service.ts
@@ -46,20 +46,45 @@ async function fetchPageBySlug(slug: string): Promise<CachedPage | null> {
   });
 }
 
+function normalizeSlug(slug: string): string {
+  if (!slug || slug === "/") {
+    return "home";
+  }
+  return slug;
+}
+
+/**
+ * Fetches a published, publicly visible page by its slug.
+ *
+ * An empty slug or "/" is treated as the "home" page slug.
+ *
+ * @param slug - The URL slug for the page (e.g. "about", "blog/post-1", or "/").
+ * @returns A promise that resolves to the matching cached page, or `null` if no page exists.
+ */
 export function getPageBySlug(slug: string): Promise<CachedPage | null> {
-  const realSlug = !slug || slug === "/" ? "home" : slug;
+  const realSlug = normalizeSlug(slug);
   return fetchPageBySlug(realSlug);
 }
 
+/**
+ * Returns a cached version of {@link getPageBySlug} for the given slug.
+ *
+ * Uses Next.js `unstable_cache` to cache the result keyed by the slug. The cache
+ * is tagged with `page[slug]` so it can be revalidated or invalidated elsewhere.
+ *
+ * @param slug - The URL slug for the page to retrieve from cache.
+ * @returns A promise that resolves to the cached page data, or `null` if not found.
+ */
 export function getCachedPageBySlug(slug: string): Promise<CachedPage | null> {
+  const realSlug = normalizeSlug(slug);
   return unstable_cache(
     async () => {
-      return getPageBySlug(slug);
+      return getPageBySlug(realSlug);
     },
-    [`slug-${slug}`],
+    [`slug-${realSlug}`],
     {
       revalidate: false,
-      tags: [`page[${slug}]`],
+      tags: [`page[${realSlug}]`],
     }
   )();
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a page lookup service for retrieving pages by slug.
  * Results now include page tags and consistent SEO/metadata fields.
  * Slug normalization: blank or root slugs resolve to the home page.
  * Introduced a per-slug cached retrieval path that memoizes results, disables revalidation, and tags cache entries for targeted invalidation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->